### PR TITLE
Do not set `-Werror` by default.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build
         run: |
-          cabal configure --enable-optimization --enable-tests --write-ghc-environment-files=always
+          cabal configure --enable-optimization --enable-tests --write-ghc-environment-files=always --ghc-options="-Wall -Werror"
           cabal build
 
       - name: Test
@@ -89,10 +89,10 @@ jobs:
           enable-stack: true
 
       - name: Build
-        run: stack build --coverage --test --no-run-tests
+        run: stack build --pedantic --coverage --test --no-run-tests
 
       - name: Test
-        run: stack build --coverage --test
+        run: stack build --pedantic --coverage --test
         timeout-minutes: 10
 
       - name: Generate coverage report

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,6 +50,17 @@ Examples in the Haddock documentation are tested using [`doctest-parallel`].
 [QuickCheck]: https://hackage.haskell.org/package/QuickCheck
 [`doctest-parallel`]: https://github.com/martijnbastiaan/doctest-parallel
 
+All warnings are enabled for builds.
+If a certain warning is unavoidable, it should only be disabled on a per file basis.
+While the warnings are not errors by default, code with compiler warnings will not
+be merged, and the continuous build upgrades these to errors.
+To upgrade compiler warnings to errors locally, use the `--pedantic` flag.
+
+```bash
+$ stack build --pedantic
+$ stack test --pedantic
+```
+
 ### Dependencies
 
 This project aims to avoid using too many heavy dependencies.

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,6 @@ default-extensions:
 
 ghc-options:
 - -Wall
-- -Werror
 
 dependencies:
 - ad >= 4.5 && < 4.6

--- a/symtegration.cabal
+++ b/symtegration.cabal
@@ -74,7 +74,7 @@ library
   default-extensions:
       LambdaCase
       OverloadedStrings
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
   build-depends:
       ad ==4.5.*
     , base >=4.18 && <4.22
@@ -91,7 +91,7 @@ test-suite examples
   default-extensions:
       LambdaCase
       OverloadedStrings
-  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ad ==4.5.*
     , base >=4.18 && <4.22
@@ -141,7 +141,7 @@ test-suite spec
   default-extensions:
       LambdaCase
       OverloadedStrings
-  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover ==2.11.*
   build-depends:


### PR DESCRIPTION
Continuous builds will still enable the flag, and the contribution guide now recommends setting it when testing locally.

This change should allow the package to be uploaded to Hackage.  Relevant to https://github.com/symtegration/symtegration/issues/18.